### PR TITLE
Correct fileExists to resolve with false on 404, not 400

### DIFF
--- a/lib/ArtifactoryAPI.js
+++ b/lib/ArtifactoryAPI.js
@@ -126,7 +126,7 @@ ArtifactoryAPI.prototype.fileExists = function (repoKey, remotefilePath) {
     case 200:
       deferred.resolve(true);
       break;
-    case 400:
+    case 404:
       deferred.resolve(false);
       break;
     default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifactory-api",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A module for interacting with Artifactory API",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
First off, thanks for making this.

Found that fileExists isn't resolving properly because it's catching a 400 and resolving with false, instead of a 404. 404 indicates the file doesn't exist while a 400 is a malformed request. We confirmed this by trying to find the file against our artifactory with Postman.

Please merge when you get a chance. Thanks!
