### PR TITLE
Fix incorrectly named response variable in downloadFile

### DIFF
--- a/lib/ArtifactoryAPI.js
+++ b/lib/ArtifactoryAPI.js
@@ -261,7 +261,7 @@ ArtifactoryAPI.prototype.downloadFile = function (repoKey, remotefilePath, desti
         }
       });
     } else {
-      deferred.reject('Server returned ' + respo.statusCode);
+      deferred.reject('Server returned ' + resp.statusCode);
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artifactory-api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A module for interacting with Artifactory API",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
Was trying to reject w/ `respo.statusCode` when it should have been `resp.statusCode`.
