### PR TITLE
Add Ability to pass checksums to uploadFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ API: [FileInfo](http://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API
   ```
   All this info will be available in the *fileInfoJson* object that is returned as part of the promise resolution.
 
-### uploadFile(repoKey, remotefilePath, localfilePath, forceUpload)
+### uploadFile(repoKey, remotefilePath, fileToUploadPath, forceUpload, checksums)
 Uploads a file to artifactory. All you need to provide is the repoKey, the remote path where you want to upload the file and the local path of the file you want to upload. If the file already exists in the server it will fail unless you provide the forceUpload flag with a true value. In that case, it will overwite the file in the server.
 
 API: [DeployArtifact](http://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-DeployArtifact)

--- a/lib/ArtifactoryAPI.js
+++ b/lib/ArtifactoryAPI.js
@@ -144,9 +144,12 @@ ArtifactoryAPI.prototype.fileExists = function (repoKey, remotefilePath) {
  * @param   {string} remotefilePath The path to the file inside the repo. (in the server)
  * @param   {string} fileToUploadPath Absolute or relative path to the file to upload.
  * @param   {boolean} [forceUpload=false] Flag indicating if the file should be upload if it already exists.
+ * @param   {object} checksums
+ * @param   {string} checksums.md5
+ * @param   {string} checksums.sha1
  * @returns {object} A QPromise to a json object with creation info as specified in the {@link http://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-DeployArtifact|DeployArtifact} Artifactory API.
  */
-ArtifactoryAPI.prototype.uploadFile = function (repoKey, remotefilePath, fileToUploadPath, forceUpload) {
+ArtifactoryAPI.prototype.uploadFile = function (repoKey, remotefilePath, fileToUploadPath, forceUpload, checksums) {
   var deferred = Q.defer(),
     overwriteFileInServer = forceUpload || false,
     isRemote = !!fileToUploadPath.match(/^https?:\/\//i),
@@ -175,6 +178,11 @@ ArtifactoryAPI.prototype.uploadFile = function (repoKey, remotefilePath, fileToU
       },
       strictSSL: false
     };
+
+  if(typeof checksums == "object") {
+    if(checksums.sha1) options.headers['X-Checksum-Sha1'] = checksums.sha1
+    if(checksums.md5) options.headers['X-Checksum-Md5'] = checksums.md5
+  }
 
   //Check if file exists..
   this.fileExists(repoKey, remotefilePath).then(function (fileExists) {


### PR DESCRIPTION
This fixes #5

Simply pass in a checksum object containing md5, sha1, or both:

``` js
{
  md5: 'somemd5stuffhere',
  sha1: 'yoursha1resulthere'
}
```
